### PR TITLE
* Slrclub, ppompu 위주로 크롤링 되는 원인 찾기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 .env
 *.log.*
 data/*
+
+.project
+.pydevproject
+
+/.vscode

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 - 뽐뿌 [자유게시판](http://www.ppomppu.co.kr/zboard/zboard.php?id=freeboard)
 - 웃대 [베스트오브베스트](http://www.todayhumor.co.kr/board/list.php?table=bestofbest)
 - slrclub [자유게시판](http://www.slrclub.com/bbs/zboard.php?id=free)
-- 루리웹 [커뮤니티 유머게시판](http://bbs2.ruliweb.daum.net/gaia/do/ruliweb/default/community/2078/list?bbsId=G005)
-
+- 루리웹 [유머 베스트 게시판](http://bbs.ruliweb.com/best/selection)
+- 루리웹 [핫딜 게시판](http://bbs.ruliweb.com/market/board/1020)
+- 루리웹 [취미 게시판](http://bbs.ruliweb.com/hobby)
 
 ## 설치 및 개발 환경
 - python 3.x, [Mongodb](https://www.mongodb.org), [virtualwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/)

--- a/crawler/serializers.py
+++ b/crawler/serializers.py
@@ -6,13 +6,15 @@ import datetime
 import time
 
 
-def payload_serializer(*, type: str, id: int, link: str, count: int,
+def payload_serializer(*, type: str, id: int = None, link: str, count: int,
                        title: str) -> dict:
     utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
-    return {'type': type,
-            'id': id,
+    dic = {'type': type,
             'link': link,
             'count': count,
             'title': title,
             'date': utc_now.isoformat()
             }
+    
+    dic['id'] = id
+    return dic

--- a/crawler/worker/base.py
+++ b/crawler/worker/base.py
@@ -9,6 +9,9 @@ from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup
 
+import sys
+sys.path.append("..")
+
 from ..config import crawler_config
 from ..database import MongoDB
 
@@ -32,9 +35,17 @@ class BaseSite:
         l.info('insert data: {}'.format(data))
         document = 'archive'
 
-        c = self.db.query(document) \
-            .find_one({'type': data['type'],
-                       'id': data['id']})
+        objid = None
+        c = None
+        if data.get('id') is None:
+            c = self.db.query(document) \
+                .find_one({'type': data['type'],
+                           'title': data['title']})            
+        else:
+            c = self.db.query(document) \
+                .find_one({'type': data['type'],
+                           'id': data['id']})
+                
         if c is None:
             objid = self.db.insert(document, data=data)
             l.info('insert data: {}, objid: {}'.format(data, objid))
@@ -46,6 +57,7 @@ class BaseSite:
                 objid = self.db.update(document, c=c, data=d)
                 if objid['ok']:
                     return c['_id']
+                
         return objid
 
     def crawling(self, url, encoding='utf-8'):

--- a/crawler/worker/clien.py
+++ b/crawler/worker/clien.py
@@ -17,12 +17,13 @@ class Clien(BaseSite):
         BaseSite.__init__(self)
         self.threshold = threshold
         self.page_max = page_max
+        self.article_base_url = 'https://www.clien.net'
 
     def crawler(self):
         l = logger.getChild('Clien.crawler')
         for page in range(1, self.page_max, 1):
-            host = 'http://clien.net/cs2/bbs/board.php'
-            query = 'bo_table=park&page={}'.format(page)
+            host = 'http://clien.net/service/board/park'
+            query = 'od=T31&po={}'.format(page)
             self.url = '{host}?{query}'.format(host=host, query=query)
             soup = self.crawling(self.url)
             if soup is None:
@@ -34,17 +35,15 @@ class Clien(BaseSite):
         l = logger.getChild('Clien.do')
         l.info('start {} crawler'.format(self.type))
         for soup in self.crawler():
-            for ctx in soup.select('tr.mytr'):
-                _temp = ctx.select('td.post_subject span')
-                if len(_temp) != 0 and \
-                        int(_temp[0].text[1:-1]) >= self.threshold:
-                    _id = ctx.select('td')[0].text
-                    _count = _temp[0].text[1:-1]
-                    _title = ctx.select('td.post_subject a')[0].text
-                    _link = self.url.split('?')[0] + '?' + ctx.select('a')[0] \
-                        .get('href') \
-                        .split('?')[1]
-                    obj = payload_serializer(type=self.type, id=_id,
-                                             link=_link, count=_count,
-                                             title=_title)
+            # https://github.com/liza183/clienBBS/blob/master/clien.py 
+            for ctx in soup.find_all('div', {"class": 'list_item symph_row'}):
+                #_temp = ctx.select('div#list_reply reply_symph')
+                _count = int(ctx.findAll("div")[3].span.text)
+                if _count >= self.threshold:
+                    _title = ctx.findAll("span")[1].text
+                    _link = self.article_base_url + ctx.find("a",{"class":"list_subject"})['href']
+                    _author = ctx['data-author-id'].strip()
+                    _timestamp = ctx.find("div",{"class":"list_time"}).span.span.text
+                        
+                    obj = payload_serializer(type=self.type, link=_link, count=_count, title=_title)
                     self.insert_or_update(obj)

--- a/crawler/worker/ruliweb_hobby.py
+++ b/crawler/worker/ruliweb_hobby.py
@@ -11,7 +11,7 @@ from ..serializers import payload_serializer
 logger = logging.getLogger(__name__)
 
 
-class Ruliweb(BaseSite):
+class RuliwebHobby(BaseSite):
 
     def __init__(self, *, threshold=15, page_max=20):
         BaseSite.__init__(self)
@@ -19,7 +19,7 @@ class Ruliweb(BaseSite):
         self.pageMax = page_max
 
     def crawler(self):
-        l = logger.getChild('Ruliweb.crawler')
+        l = logger.getChild('RuliwebHobby.crawler')
         for page in range(1, self.pageMax, 1):
             host = 'http://bbs.ruliweb.com/hobby'
             query = 'type=hit&orderby=regdate&pageIndex={}'.format(page)
@@ -31,14 +31,13 @@ class Ruliweb(BaseSite):
             yield soup
 
     def do(self):
-        l = logger.getChild('Ruliweb.do')
+        l = logger.getChild('RuliwebHobby.do')
         l.info('start {} crawler'.format(self.type))
         for soup in self.crawler():
             for ctx in soup.select('tbody tr'):
                 _temp = ctx.select('span.num_reply span.num')
-                if len(_temp) != 0 and \
-                        int(_temp[0].text) >= self.threshold:
-                    _count = _temp[0].text
+                _count = _temp[0].text
+                if int(_count) >= self.threshold:
                     _title = ctx.select('a.subject_text')[0].contents[0]
                     _link = ctx.select('a')[1].get('href')
                     obj = payload_serializer(type=self.type, link=_link, count=_count,

--- a/crawler/worker/ruliweb_hotdeal.py
+++ b/crawler/worker/ruliweb_hotdeal.py
@@ -11,7 +11,7 @@ from ..serializers import payload_serializer
 logger = logging.getLogger(__name__)
 
 
-class Ruliweb(BaseSite):
+class RuliwebHotdeal(BaseSite):
 
     def __init__(self, *, threshold=15, page_max=20):
         BaseSite.__init__(self)
@@ -19,10 +19,10 @@ class Ruliweb(BaseSite):
         self.pageMax = page_max
 
     def crawler(self):
-        l = logger.getChild('Ruliweb.crawler')
+        l = logger.getChild('RuliwebHotdeal.crawler')
         for page in range(1, self.pageMax, 1):
-            host = 'http://bbs.ruliweb.com/hobby'
-            query = 'type=hit&orderby=regdate&pageIndex={}'.format(page)
+            host = 'http://bbs.ruliweb.com/market/board/1020'
+            query = 'page={}'.format(page, page)
             self.url = '{host}?{query}'.format(host=host, query=query)
             soup = self.crawling(self.url)
             if soup is None:
@@ -31,15 +31,18 @@ class Ruliweb(BaseSite):
             yield soup
 
     def do(self):
-        l = logger.getChild('Ruliweb.do')
+        l = logger.getChild('RuliwebHotdeal.do')
         l.info('start {} crawler'.format(self.type))
         for soup in self.crawler():
             for ctx in soup.select('tbody tr'):
-                _temp = ctx.select('span.num_reply span.num')
-                if len(_temp) != 0 and \
-                        int(_temp[0].text) >= self.threshold:
-                    _count = _temp[0].text
-                    _title = ctx.select('a.subject_text')[0].contents[0]
+                tr_class = ctx.attrs['class']
+                if len(tr_class) == 2 and tr_class[1] == "notice":
+                    continue
+                
+                _temp = ctx.select("td.hit")
+                _count = int(_temp[0].text)
+                if _count >= self.threshold:
+                    _title = ctx.select('a')[1].text
                     _link = ctx.select('a')[1].get('href')
                     obj = payload_serializer(type=self.type, link=_link, count=_count,
                                              title=_title)

--- a/crawler/worker/ruliweb_humor.py
+++ b/crawler/worker/ruliweb_humor.py
@@ -11,7 +11,7 @@ from ..serializers import payload_serializer
 logger = logging.getLogger(__name__)
 
 
-class Ruliweb(BaseSite):
+class RuliwebHumor(BaseSite):
 
     def __init__(self, *, threshold=15, page_max=20):
         BaseSite.__init__(self)
@@ -19,10 +19,10 @@ class Ruliweb(BaseSite):
         self.pageMax = page_max
 
     def crawler(self):
-        l = logger.getChild('Ruliweb.crawler')
+        l = logger.getChild('RuliwebHumor.crawler')
         for page in range(1, self.pageMax, 1):
-            host = 'http://bbs.ruliweb.com/hobby'
-            query = 'type=hit&orderby=regdate&pageIndex={}'.format(page)
+            host = 'http://bbs.ruliweb.com/best/selection'
+            query = 'page={}'.format(page, page)
             self.url = '{host}?{query}'.format(host=host, query=query)
             soup = self.crawling(self.url)
             if soup is None:
@@ -31,15 +31,14 @@ class Ruliweb(BaseSite):
             yield soup
 
     def do(self):
-        l = logger.getChild('Ruliweb.do')
+        l = logger.getChild('RuliwebHumor.do')
         l.info('start {} crawler'.format(self.type))
         for soup in self.crawler():
             for ctx in soup.select('tbody tr'):
                 _temp = ctx.select('span.num_reply span.num')
-                if len(_temp) != 0 and \
-                        int(_temp[0].text) >= self.threshold:
-                    _count = _temp[0].text
-                    _title = ctx.select('a.subject_text')[0].contents[0]
+                _count = _temp[0].text
+                if int(_count) >= self.threshold:
+                    _title = ctx.select('a')[1].text
                     _link = ctx.select('a')[1].get('href')
                     obj = payload_serializer(type=self.type, link=_link, count=_count,
                                              title=_title)

--- a/crawler/worker/slrclub.py
+++ b/crawler/worker/slrclub.py
@@ -42,7 +42,7 @@ class Slrclub(BaseSite):
                         _id = text.get('href').split('no=')[1]
                         _count = _temp[1:-1]
                         _title = text.text
-                        _link = self.url.split('zboard.php')[0] + \
+                        _link = self.url.split('/bbs')[0] + \
                             text.get('href')
                         obj = payload_serializer(type=self.type, id=_id,
                                                  link=_link, count=_count,

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,5 +1,4 @@
 beautifulsoup4==4.4.1
-fancycompleter==0.4
 flake8==2.5.4
 flake8-import-order==0.7
 Flask==0.10.1
@@ -10,7 +9,6 @@ mccabe==0.4.0
 mirakuru==0.6.1
 ordereddict==1.1
 path.py==8.1.2
-pdbpp==0.8.3
 pep8==1.7.0
 port-for==0.3.1
 py==1.4.31

--- a/serve.py
+++ b/serve.py
@@ -15,7 +15,9 @@ from crawler.config import crawler_config
 from crawler.exc import SkipCrawler, TerminatedCrawler
 from crawler.worker.clien import Clien
 from crawler.worker.ppomppu import Ppomppu
-from crawler.worker.ruliweb import Ruliweb
+from crawler.worker.ruliweb_humor import RuliwebHumor
+from crawler.worker.ruliweb_hobby import RuliwebHobby
+from crawler.worker.ruliweb_hotdeal import RuliwebHotdeal
 from crawler.worker.slrclub import Slrclub
 from crawler.worker.todayhumor import Todayhumor
 
@@ -34,22 +36,29 @@ class Crawler(threading.Thread):
     def run(self):
         l = logger.getChild('Crawler.run')
         site = self.queue.get()
-        try:
-            site.do()
-        except ServerSelectionTimeoutError:
-            self.is_stop = True
-        except SkipCrawler:
-            l.info('crawler skip')
+        
+        while True:
+            try:
+                site.do()
+            except ServerSelectionTimeoutError:
+                self.is_stop = True
+            except SkipCrawler:
+                l.info('crawler skip')
+            except:
+                l.error('unhandled exception')
+            
         self.queue.task_done()
 
 
 def crawler(*, queue: Queue):
     sites = [
-        Clien(threshold=20, page_max=20),
-        Ppomppu(threshold=30, page_max=20),
-        Ruliweb(threshold=15, page_max=20),
-        Slrclub(threshold=15, page_max=20),
-        Todayhumor(threshold=100, page_max=5)
+        Clien(threshold=20, page_max=10),
+        Ppomppu(threshold=30, page_max=10),
+        Slrclub(threshold=15, page_max=10),
+        Todayhumor(threshold=20, page_max=10),
+        RuliwebHobby(threshold=15, page_max=10),
+        RuliwebHumor(threshold=15, page_max=10),
+        RuliwebHotdeal(threshold=15, page_max=10),
     ]
     thread_num = len(sites)
     for site in sites:


### PR DESCRIPTION
게시판 구조가 바뀌어서 크롤링 실패 나는 것과, 오류 처리 일부 보강 했습니다.
제가 주로 가는 크롤링 되는 대상 게시판 몇개 확장했어요.
---
* 원인
	* 크롤링에서 실패나서 그랬음.
* 해결책
	* Ruliweb 문서 구조 바뀐 것 되살리기
	* 오늘의 유머 크롤링 기준 낮춤.
	* Client 문서 구조 바뀐 것 대응.

* 크롤링 실패시에도 재시도 하도록 수정.
* SLR 클럽 path 잘못 생성하는 것 수정.
* Client 게시판 path 수정.
* 게시물 id가 없는 경우가 있음.
	* 중복 검사용 키가 _id로 되어있길래, id가 없을땐 무조건 insert 하도록 변경한 상황.
	* 게시물 이름같은 값을 기준값으로 잡아야 할 듯.
		* Title 단위로 create or update 처리.
* 루리웹 핫딜 게시판 크롤링 추가
	* <a href="http://bbs.ruliweb.com/market/board/1020">http://bbs.ruliweb.com/market/board/1020</a>
* 루리웹 유게 (핫글) 게시판 크롤링 추가.
	* <a href="http://bbs.ruliweb.com/best/selection">http://bbs.ruliweb.com/best/selection</a>
* Mysql 로 변환?
	* 안함.